### PR TITLE
Use pattern rule and init.sh for all apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,6 @@ upload-images: kind ## Upload app images into the cluster
 		fi; \
 	done
 
-create-namespaces: kind ## Create the namespace for each app in apps directory
-	@for dir in apps/*/; do \
-		ns=$$(basename "$$dir"); \
-		kubectl get namespace "$$ns" >/dev/null 2>&1 || kubectl create namespace "$$ns"; \
-	done
-
 label-namespaces-egress-service: kind ## Label the namespace for each app in apps directory with qpoint-egress=service
 	@for dir in apps/*/; do \
 		ns=$$(basename "$$dir"); \
@@ -98,7 +92,7 @@ label-namespaces-egress-disable: kind ## Label the namespace for each app in app
 		fi; \
 	done
 
-up: ensure-deps ensure-images cluster cert-manager upload-images create-namespaces ## Bring up the demo environment
+up: ensure-deps ensure-images cluster cert-manager upload-images ## Bring up the demo environment
 
 down: ## Teardown the demo environment
 	kind delete cluster --name demo
@@ -131,33 +125,33 @@ qpoint: ensure-deps ## Install qpoint gateway & operator
 
 ##@ Apps
 
-simple-alpine: up ## Deploy the "simple-alpine" app for curl'ing external APIs
-	@kubectl delete -f apps/simple-alpine/deployment.yaml --ignore-not-found
-	@kubectl apply -f apps/simple-alpine/deployment.yaml
+%-app: ensure-deps cluster cert-manager ## Pattern rule for applications
+	@$(MAKE) ensure-image APP=$* > /dev/null
+	@$(MAKE) ensure-namespace APP=$* > /dev/null
+	@$(MAKE) upload-image APP=$* > /dev/null
+	apps/$*/init.sh apps/$*
 
-simple-fedora: up ## Deploy the "simple-fedora" app for curl'ing external APIs
-	@kubectl delete -f apps/simple-fedora/deployment.yaml --ignore-not-found
-	@kubectl apply -f apps/simple-fedora/deployment.yaml
+ensure-image: ## Rule to ensure the Docker image exists for app
+	dir=apps/$(APP)
+	if [ -f "$$dir/Dockerfile" ]; then \
+		image_name="demo-$(APP)"; \
+		if [ -z "$$(docker images -q $$image_name)" ]; then \
+			echo "Building app image: $$image_name"; \
+			docker build -t "$$image_name" "$$dir"; \
+		else \
+			echo "Image $$image_name already exists"; \
+		fi; \
+	fi
 
-simple: up ## Deploy the "simple" app for curl'ing external APIs
-	@kubectl delete -f apps/simple/deployment.yaml --ignore-not-found
-	@kubectl apply -f apps/simple/deployment.yaml
+ensure-namespace: ## Create the namespace for app
+	kubectl get namespace "$(APP)" >/dev/null 2>&1 || kubectl create namespace "$(APP)";
 
-artillery: up ## Deploy the "artillery" app for hammering multiple APIs
-	@kubectl delete -f apps/artillery/deployment.yaml --ignore-not-found
-	@kubectl apply -f apps/artillery/deployment.yaml
-
-datadog: up ## Deploy the "datadog" app for reporting to datadog
-	@helm uninstall datadog-agent -n datadog --ignore-not-found
-	@helm repo add datadog https://helm.datadoghq.com
-	@helm repo update
-	@helm install datadog-agent -f apps/datadog/values.yaml datadog/datadog -n datadog
-
-newrelic: up ## Deploy the "newrelic" app for reporting to newrelic
-	@helm uninstall newrelic-bundle -n newrelic --ignore-not-found
-	@helm repo add newrelic https://helm-charts.newrelic.com
-	@helm repo update
-	@helm install newrelic-bundle newrelic/nri-bundle -f apps/newrelic/values.yaml -n newrelic
+upload-image: ## Upload app image into the cluster
+	dir=apps/$(APP)
+	if [ -f "$${dir}/Dockerfile" ]; then \
+		image_name="demo-$(APP)"; \
+		kind load docker-image "$$image_name:latest" --name demo; \
+	fi;
 
 ##@ Demo
 

--- a/apps/artillery/init.sh
+++ b/apps/artillery/init.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+kubectl delete -f "$1"/deployment.yaml --ignore-not-found
+kubectl apply -f "$1"/deployment.yaml

--- a/apps/datadog/init.sh
+++ b/apps/datadog/init.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+helm uninstall datadog-agent -n datadog --ignore-not-found
+helm repo add datadog https://helm.datadoghq.com
+helm repo update
+helm install datadog-agent -f "$1"/values.yaml datadog/datadog -n datadog

--- a/apps/newrelic/init.sh
+++ b/apps/newrelic/init.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+
+helm uninstall newrelic-bundle -n newrelic --ignore-not-found
+helm repo add newrelic https://helm-charts.newrelic.com
+helm repo update
+helm install newrelic-bundle newrelic/nri-bundle -f "$1"/values.yaml -n newrelic

--- a/apps/simple-alpine/init.sh
+++ b/apps/simple-alpine/init.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+kubectl delete -f "$1"/deployment.yaml --ignore-not-found
+kubectl apply -f "$1"/deployment.yaml

--- a/apps/simple-fedora/init.sh
+++ b/apps/simple-fedora/init.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+kubectl delete -f "$1"/deployment.yaml --ignore-not-found
+kubectl apply -f "$1"/deployment.yaml

--- a/apps/simple/init.sh
+++ b/apps/simple/init.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+kubectl delete -f "$1"/deployment.yaml --ignore-not-found
+kubectl apply -f "$1"/deployment.yaml


### PR DESCRIPTION
This pull request makes use of a pattern match to identify apps and moves app specific configuration into a standard `init.sh` script.

The requirement is that anything that has a target that ends in `-app` will be matched. For example, `make blah-app` would match for `blah` as the app name. This has the following advantages:

- Only build Docker images for apps one is using.
- Only add namespaces for the apps that have been deployed into the cluster.
- New apps simply add a directory with the convention and the Makefile doesn't require any changes.

As an example,

```
make simple-app
No kind clusters found.
Creating cluster "demo" ...
 ✓ Ensuring node image (kindest/node:v1.27.3) 🖼
 ✓ Preparing nodes 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing CNI 🔌
 ✓ Installing StorageClass 💾
Set kubectl context to "kind-demo"
You can now use your cluster with:

kubectl cluster-info --context kind-demo

Thanks for using kind! 😊
Installing cert-manager...
NAME: cert-manager
LAST DEPLOYED: Thu Dec  7 23:58:05 2023
NAMESPACE: cert-manager
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
cert-manager v1.13.2 has been deployed successfully!

In order to begin issuing certificates, you will need to set up a ClusterIssuer
or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).

More information on the different types of issuers and how to configure them
can be found in our documentation:

https://cert-manager.io/docs/configuration/

For information on how to configure cert-manager to automatically provision
Certificates for Ingress resources, take a look at the `ingress-shim`
documentation:

https://cert-manager.io/docs/usage/ingress/
apps/simple/init.sh apps/simple
deployment.apps/simple created
```

Or

```
make datadog-app
Installing cert-manager...
apps/datadog/init.sh apps/datadog
release "datadog-agent" uninstalled
"datadog" already exists with the same configuration, skipping
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "qpoint" chart repository
...Successfully got an update from the "jetstack" chart repository
...Successfully got an update from the "datadog" chart repository
...Successfully got an update from the "newrelic" chart repository
Update Complete. ⎈Happy Helming!⎈
NAME: datadog-agent
LAST DEPLOYED: Thu Dec  7 23:59:36 2023
NAMESPACE: datadog
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Datadog agents are spinning up on each node in your cluster. After a few
minutes, you should see your agents starting in your event stream:
    https://app.datadoghq.com/event/explorer

###################################################################################
####   WARNING: Cluster-Agent should be deployed in high availability mode     ####
###################################################################################

The Cluster-Agent should be in high availability mode because the following features
are enabled:
* Admission Controller

To run in high availability mode, our recommendation is to update the chart
configuration with:
* set `clusterAgent.replicas` value to `2` replicas .
* set `clusterAgent.createPodDisruptionBudget` to `true`.
```