### PR TITLE
Fixes issue with Artillery which rejected self-signed

### DIFF
--- a/apps/artillery/artillery-config.yaml
+++ b/apps/artillery/artillery-config.yaml
@@ -3,6 +3,8 @@ config:
   phases:
     - duration: 300
       arrivalRate: 2
+  tls:
+    rejectUnauthorized: false
 
 scenarios:
   - name: "Google APIs"


### PR DESCRIPTION
Leverages https://www.artillery.io/docs/reference/test-script#tls---self-signed-certificates so that Artillery accepts self-signed certificates.