### PR TITLE
Use NODE_EXTRA_CA_CERTS to inject the Qpoint root CA

### DIFF
--- a/apps/artillery/deployment.yaml
+++ b/apps/artillery/deployment.yaml
@@ -17,3 +17,6 @@ spec:
         - name: artillery
           image: demo-artillery:latest
           imagePullPolicy: IfNotPresent
+          env:
+          - name: NODE_EXTRA_CA_CERTS
+            value: "/etc/ssl/certs/ca-certificates.crt"


### PR DESCRIPTION
This replaces https://github.com/qpoint-io/demos/pull/13.