### PR TITLE
Adds Go sample implementation

### DIFF
--- a/apps/impl-go/Dockerfile
+++ b/apps/impl-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest AS build
+FROM golang:1.21-bookworm AS build
 
 WORKDIR /app
 
@@ -6,7 +6,7 @@ COPY main.go .
 
 RUN go build -o sample-go main.go
 
-FROM ubuntu:latest
+FROM ubuntu:jammy
 
 RUN apt-get update
 RUN apt-get -y install ca-certificates tini

--- a/apps/impl-go/Dockerfile
+++ b/apps/impl-go/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:latest AS build
+
+WORKDIR /app
+
+COPY main.go .
+
+RUN go build -o sample-go main.go
+
+FROM ubuntu:latest
+
+RUN apt-get update
+RUN apt-get -y install tini
+
+COPY --from=build /app/sample-go /usr/local/bin/sample-go
+
+CMD ["sleep", "infinity"]
+ENTRYPOINT ["tini", "--"]

--- a/apps/impl-go/Dockerfile
+++ b/apps/impl-go/Dockerfile
@@ -9,7 +9,7 @@ RUN go build -o sample-go main.go
 FROM ubuntu:latest
 
 RUN apt-get update
-RUN apt-get -y install tini
+RUN apt-get -y install ca-certificates tini
 
 COPY --from=build /app/sample-go /usr/local/bin/sample-go
 

--- a/apps/impl-go/README.md
+++ b/apps/impl-go/README.md
@@ -1,0 +1,49 @@
+# HTTP Client with Optional CA Certificate Injection in Go
+
+## Overview
+This Go program is a command-line tool that makes an HTTP GET request to a specified URL. It is capable of using a custom CA (Certificate Authority) certificate, if provided, to establish trust with the server during the TLS handshake. This feature is particularly useful when dealing with self-signed certificates or certificates signed by a private CA.
+
+## Requirements
+- Go (version 1.11 or later)
+
+## Installation
+Clone the repository or download the source code to your local machine.
+
+## Usage
+The program can be run in two modes:
+1. **Basic Mode:** Make an HTTP GET request without custom CA certificate.
+2. **CA Certificate Mode:** Make an HTTP GET request with a custom CA certificate.
+
+### Basic Mode
+```
+go run main.go [URL]
+```
+Replace `[URL]` with the desired HTTP/HTTPS URL.
+
+### CA Certificate Mode
+```
+go run main.go [URL] [CA-Certificate-File]
+```
+- Replace `[URL]` with the desired HTTP/HTTPS URL.
+- Replace `[CA-Certificate-File]` with the path to your CA certificate file.
+
+## Proxy Support
+If you have an HTTP or HTTPS proxy set up in your environment, the script can use it. Set the `HTTP_PROXY` or `HTTPS_PROXY` environment variables to your proxy server's URL.
+
+```
+export HTTP_PROXY=http://proxyserver:port
+export HTTPS_PROXY=https://proxyserver:port
+```
+
+## Example
+1. Basic Mode:
+   ```
+   go run main.go https://example.com
+   ```
+2. CA Certificate Mode:
+   ```
+   go run main.go https://example.com /path/to/ca-cert.pem
+   ```
+
+## Note
+The program, in CA Certificate Mode, expects the CA certificate file to be in PEM format.

--- a/apps/impl-go/README.md
+++ b/apps/impl-go/README.md
@@ -1,7 +1,7 @@
 # HTTP Client with Optional CA Certificate Injection in Go
 
 ## Overview
-This Go program is a command-line tool that makes an HTTP GET request to a specified URL. It is capable of using a custom CA (Certificate Authority) certificate, if provided, to establish trust with the server during the TLS handshake. This feature is particularly useful when dealing with self-signed certificates or certificates signed by a private CA.
+This Go program is a command-line tool that makes an HTTP GET request to a specified URL. It is capable of using a custom CA (Certificate Authority) certificate, if provided, to establish trust with the server during the TLS handshake. This feature is particularly useful when dealing with self-signed certificates or certificates signed by a private CA. The script also automatically respects `HTTP_PROXY` and `HTTPS_PROXY` environment variables.
 
 ## Requirements
 - Go (version 1.11 or later)

--- a/apps/impl-go/deployment.yaml
+++ b/apps/impl-go/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: impl-go
+  namespace: impl-go
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: impl-go
+  template:
+    metadata:
+      labels:
+        app: impl-go
+    spec:
+      containers:
+      - name: impl-go
+        image: demo-impl-go
+        imagePullPolicy: Never

--- a/apps/impl-go/go.mod
+++ b/apps/impl-go/go.mod
@@ -1,0 +1,3 @@
+module qpoint-go-sample
+
+go 1.21.4

--- a/apps/impl-go/init.sh
+++ b/apps/impl-go/init.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+bin/kubectl delete -f "$1"/deployment.yaml --ignore-not-found
+bin/kubectl apply -f "$1"/deployment.yaml

--- a/apps/impl-go/main.go
+++ b/apps/impl-go/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"os"
+)
+
+func main() {
+	// Check if a URL argument is provided
+	if len(os.Args) < 2 {
+		fmt.Println("Usage: go run main.go [url] [optional: ca-certificate-file]")
+		os.Exit(1)
+	}
+
+	// Get the URL from the command line arguments
+	url := os.Args[1]
+
+	// Set up HTTP transport that respects HTTP_PROXY and HTTPS_PROXY
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	}
+
+	// Check if a CA certificate file is provided
+	if len(os.Args) == 3 {
+		caCertFile := os.Args[2]
+
+		// Load the CA certificate
+		caCert, err := os.ReadFile(caCertFile)
+		if err != nil {
+			fmt.Printf("Error reading CA certificate file: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Append the CA certificate to the system's pool of trusted certificates
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			fmt.Println("Failed to append CA certificate")
+			os.Exit(1)
+		}
+
+		// Create a custom TLS config with the updated pool of certificates
+		tlsConfig := &tls.Config{
+			RootCAs: caCertPool,
+		}
+
+		// Update the transport with the custom TLS config
+		transport.TLSClientConfig = tlsConfig
+	}
+
+	// Create an HTTP client with the transport
+	client := &http.Client{Transport: transport}
+
+	// Create a new HTTP request
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		fmt.Printf("Error creating request: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Dump the HTTP request to stdout
+	dumpReq, err := httputil.DumpRequestOut(req, false)
+	if err != nil {
+		fmt.Printf("Error dumping request: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Request:\n%s\n\n", dumpReq)
+
+	// Perform the HTTP request
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Printf("Error sending request: %v\n", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	// Dump the HTTP response to stdout
+	dumpResp, err := httputil.DumpResponse(resp, false)
+	if err != nil {
+		fmt.Printf("Error dumping response: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Response:\n%s\n", dumpResp)
+}

--- a/apps/impl-go/main.go
+++ b/apps/impl-go/main.go
@@ -19,10 +19,8 @@ func main() {
 	// Get the URL from the command line arguments
 	url := os.Args[1]
 
-	// Set up HTTP transport that respects HTTP_PROXY and HTTPS_PROXY
-	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-	}
+	// Create an HTTP transport with default settings
+	transport := http.DefaultTransport.(*http.Transport).Clone()
 
 	// Check if a CA certificate file is provided
 	if len(os.Args) == 3 {


### PR DESCRIPTION
This adds a simple implementation example for Golang on how http clients can be configured to respect http(s)_proxy as well as optionally inject a trusted CA cert directly into Go http client versus trusting it at a system level. 