### PR TITLE
Adds NodeJS sample implementation

### DIFF
--- a/apps/impl-nodejs/.gitignore
+++ b/apps/impl-nodejs/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/apps/impl-nodejs/Dockerfile
+++ b/apps/impl-nodejs/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:20
+
+RUN apt-get update
+RUN apt-get -y install ca-certificates tini
+
+WORKDIR /app
+
+COPY app.js /app/app.js
+COPY package.json /app/package.json
+COPY package-lock.json /app/package-lock.json
+
+WORKDIR /app
+
+RUN npm ci
+
+CMD ["sleep", "infinity"]
+ENTRYPOINT ["tini", "--"]

--- a/apps/impl-nodejs/README.md
+++ b/apps/impl-nodejs/README.md
@@ -1,0 +1,51 @@
+# Node.js HTTP Client with Optional CA Certificate Injection
+
+## Overview
+This Node.js script is a command-line tool for making HTTP or HTTPS GET requests. It includes an optional feature to use a custom CA (Certificate Authority) certificate for SSL/TLS verification, which is useful when dealing with self-signed certificates or certificates signed by a private CA.
+
+## Requirements
+- Node.js (preferably the latest stable version)
+
+## Installation
+No specific installation is required other than having Node.js installed on your system. Simply download or clone the script to your local machine.
+
+## Usage
+The script can be run in two modes:
+1. **Basic Mode:** Make an HTTP or HTTPS GET request without a custom CA certificate.
+2. **CA Certificate Mode:** Make an HTTP or HTTPS GET request with a custom CA certificate.
+
+### Basic Mode
+```
+node app.js [URL]
+```
+Replace `[URL]` with the desired HTTP or HTTPS URL.
+
+### CA Certificate Mode
+```
+node app.js [URL] [CA-Certificate-File]
+```
+- Replace `[URL]` with the desired HTTP or HTTPS URL.
+- Replace `[CA-Certificate-File]` with the path to your CA certificate file in PEM format.
+
+## Proxy Support
+If you have an HTTP or HTTPS proxy set up in your environment, the script can use it. Set the `HTTP_PROXY` or `HTTPS_PROXY` environment variables to your proxy server's URL.
+
+```
+export HTTP_PROXY=http://proxyserver:port
+export HTTPS_PROXY=https://proxyserver:port
+```
+
+## Examples
+1. Basic Mode:
+   ```
+   node app.js https://example.com
+   ```
+2. CA Certificate Mode:
+   ```
+   node app.js https://example.com /path/to/ca-cert.pem
+   ```
+
+## Note
+- The CA certificate file should be in PEM format.
+- The script handles both HTTP and HTTPS protocols.
+

--- a/apps/impl-nodejs/app.js
+++ b/apps/impl-nodejs/app.js
@@ -1,0 +1,65 @@
+import http from 'http';
+import https from 'https';
+import fs from 'fs';
+import url from 'url';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+
+// Check if the URL argument is provided
+if (process.argv.length < 3) {
+    console.log('Usage: node app.js [URL] [optional: ca-certificate-file]');
+    process.exit(1);
+}
+
+// Get the URL from the command line arguments
+const requestUrl = process.argv[2];
+
+// Function to make the HTTP/HTTPS request
+const makeRequest = (options, ca) => {
+    // Check for proxy environment variables
+    const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+
+    if (proxy) {
+        options.agent = new HttpsProxyAgent(proxy);
+    }
+
+    // If a CA is provided, add it to the options
+    if (ca) {
+        options.ca = ca;
+    }
+
+    const protocol = options.protocol === 'https:' ? https : http;
+    const req = protocol.request(options, (res) => {
+        console.log(`STATUS: ${res.statusCode}`);
+        console.log(`HEADERS: ${JSON.stringify(res.headers, null, 4)}`);
+
+        res.on('end', () => {
+            console.log('No more data in response.');
+            process.exit(0);
+        });
+    });
+
+    req.on('error', (e) => {
+        console.error(`Problem with request: ${e.message}`);
+        process.exit(1);
+    });
+
+    req.end();
+};
+
+// Parse the URL
+const options = url.parse(requestUrl);
+
+// Check if a CA certificate file is provided
+if (process.argv.length === 4) {
+    const caCertFile = process.argv[3];
+    fs.readFile(caCertFile, (err, data) => {
+        if (err) {
+            console.error(`Error reading CA certificate file: ${err.message}`);
+            process.exit(1);
+        }
+        makeRequest(options, data);
+    });
+} else {
+    makeRequest(options);
+}
+

--- a/apps/impl-nodejs/deployment.yaml
+++ b/apps/impl-nodejs/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: impl-nodejs
+  namespace: impl-nodejs
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: impl-nodejs
+  template:
+    metadata:
+      labels:
+        app: impl-nodejs
+    spec:
+      containers:
+      - name: impl-nodejs
+        image: demo-impl-nodejs
+        imagePullPolicy: Never

--- a/apps/impl-nodejs/init.sh
+++ b/apps/impl-nodejs/init.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+bin/kubectl delete -f "$1"/deployment.yaml --ignore-not-found
+bin/kubectl apply -f "$1"/deployment.yaml

--- a/apps/impl-nodejs/package-lock.json
+++ b/apps/impl-nodejs/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "impl-nodejs",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "impl-nodejs",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "https-proxy-agent": "^7.0.2"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    }
+  }
+}

--- a/apps/impl-nodejs/package.json
+++ b/apps/impl-nodejs/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "impl-nodejs",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "## Overview This Node.js script is a command-line tool for making HTTP or HTTPS GET requests. It includes an optional feature to use a custom CA (Certificate Authority) certificate for SSL/TLS verification, which is useful when dealing with self-signed certificates or certificates signed by a private CA.",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "https-proxy-agent": "^7.0.2"
+  }
+}


### PR DESCRIPTION
This adds a simple implementation example for NodeJS on how http clients can be configured to respect http(s)_proxy as well as optionally inject a trusted CA cert directly into NodeJS http client versus trusting it at a system level.