### PR TITLE
Adds Python3 sample implementation

### DIFF
--- a/apps/impl-python3/Dockerfile
+++ b/apps/impl-python3/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.9-slim
+
+RUN apt-get update
+RUN apt-get -y install ca-certificates tini
+
+WORKDIR /app
+
+COPY app.py /app/app.py
+
+CMD ["sleep", "infinity"]
+ENTRYPOINT ["tini", "--"]

--- a/apps/impl-python3/README.md
+++ b/apps/impl-python3/README.md
@@ -1,0 +1,51 @@
+# Python HTTP Client with Optional CA Certificate Injection
+
+## Overview
+This Python script is a command-line tool for making HTTP or HTTPS GET requests. It includes an optional feature to use a custom CA (Certificate Authority) certificate for SSL/TLS verification, which is useful when dealing with self-signed certificates or certificates signed by a private CA. The script also supports HTTP and HTTPS proxies through environment variables.
+
+## Requirements
+- Python 3.x
+
+## Installation
+No specific installation steps are required other than having Python 3.x installed on your system. Simply download or clone the script to your local machine.
+
+## Usage
+The script can be run in two modes:
+1. **Basic Mode:** Make an HTTP or HTTPS GET request without a custom CA certificate.
+2. **CA Certificate Mode:** Make an HTTP or HTTPS GET request with a custom CA certificate.
+
+### Basic Mode
+```
+python3 app.py [URL]
+```
+Replace `[URL]` with the desired HTTP or HTTPS URL.
+
+### CA Certificate Mode
+```
+python3 app.py [URL] [CA-Certificate-File]
+```
+- Replace `[URL]` with the desired HTTP or HTTPS URL.
+- Replace `[CA-Certificate-File]` with the path to your CA certificate file in PEM format.
+
+## Proxy Support
+If you have an HTTP or HTTPS proxy set up in your environment, the script can use it. Set the `HTTP_PROXY` or `HTTPS_PROXY` environment variables to your proxy server's URL.
+
+```
+export HTTP_PROXY=http://proxyserver:port
+export HTTPS_PROXY=https://proxyserver:port
+```
+
+## Examples
+1. Basic Mode:
+   ```
+   python3 app.py https://example.com
+   ```
+2. CA Certificate Mode:
+   ```
+   python3 app.py https://example.com /path/to/ca-cert.pem
+   ```
+
+## Note
+- The CA certificate file should be in PEM format.
+- The script handles both HTTP and HTTPS protocols and supports proxy settings through environment variables.
+

--- a/apps/impl-python3/app.py
+++ b/apps/impl-python3/app.py
@@ -1,0 +1,51 @@
+import http.client
+import ssl
+import sys
+import urllib.parse
+import os
+
+def make_request(url, ca_cert_file=None):
+    parsed_url = urllib.parse.urlparse(url)
+    proxy = os.environ.get('HTTPS_PROXY' if parsed_url.scheme == 'https' else 'HTTP_PROXY')
+
+    context = ssl.create_default_context()
+    if ca_cert_file:
+        context.load_verify_locations(ca_cert_file)
+
+    if proxy:
+        proxy_parsed = urllib.parse.urlparse(proxy)
+
+        print(f"Proxy URL: {proxy}")
+        print(f"Proxy Host: {proxy_parsed.hostname}")
+        print(f"Proxy Port: {proxy_parsed.port}")
+
+        conn = http.client.HTTPSConnection if parsed_url.scheme == "https" else http.client.HTTPConnection
+        connection = conn(proxy_parsed.hostname, proxy_parsed.port)
+        connection.set_tunnel(parsed_url.netloc)
+    else:
+        conn = http.client.HTTPSConnection if parsed_url.scheme == "https" else http.client.HTTPConnection
+        connection = conn(parsed_url.netloc, context=context if parsed_url.scheme == "https" else None)
+
+    try:
+        print(f"Sending request to {url}")
+        connection.request("GET", parsed_url.path or '/')
+        response = connection.getresponse()
+        print(f"Received response from {url}")
+        print(f"STATUS: {response.status}")
+        print(f"HEADERS: {response.headers}")
+        # print("BODY:")
+        # print(response.read().decode())
+    except Exception as e:
+        print(f"Error making request: {e}")
+    finally:
+        connection.close()
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python3 app.py [URL] [optional: ca-certificate-file]")
+        sys.exit(1)
+
+    url = sys.argv[1]
+    ca_cert_file = sys.argv[2] if len(sys.argv) > 2 else None
+    make_request(url, ca_cert_file)
+

--- a/apps/impl-python3/deployment.yaml
+++ b/apps/impl-python3/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: impl-python3
+  namespace: impl-python3
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: impl-python3
+  template:
+    metadata:
+      labels:
+        app: impl-python3
+    spec:
+      containers:
+      - name: impl-python3
+        image: demo-impl-python3
+        imagePullPolicy: Never

--- a/apps/impl-python3/init.sh
+++ b/apps/impl-python3/init.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+bin/kubectl delete -f "$1"/deployment.yaml --ignore-not-found
+bin/kubectl apply -f "$1"/deployment.yaml


### PR DESCRIPTION
This adds a simple implementation example for Python3 on how http clients can be configured to respect http(s)_proxy as well as optionally inject a trusted CA cert directly into Python3 http client versus trusting it at a system level.