### PR TITLE
Adds Ruby sample implementation

### DIFF
--- a/apps/impl-ruby/Dockerfile
+++ b/apps/impl-ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:latest
+FROM ruby:3.3-slim
 
 RUN apt-get update
 RUN apt-get -y install ca-certificates tini

--- a/apps/impl-ruby/Dockerfile
+++ b/apps/impl-ruby/Dockerfile
@@ -1,0 +1,11 @@
+FROM ruby:latest
+
+RUN apt-get update
+RUN apt-get -y install ca-certificates tini
+
+WORKDIR /app
+
+COPY app.rb /app/app.rb
+
+CMD ["sleep", "infinity"]
+ENTRYPOINT ["tini", "--"]

--- a/apps/impl-ruby/README.md
+++ b/apps/impl-ruby/README.md
@@ -1,0 +1,45 @@
+# Ruby HTTP Client with Optional CA Certificate Injection
+
+## Overview
+This Ruby script is a command-line tool for making HTTP or HTTPS GET requests. It includes an optional feature to use a custom CA (Certificate Authority) certificate for SSL/TLS verification, useful for self-signed certificates or certificates from a private CA. The script also automatically respects `HTTP_PROXY` and `HTTPS_PROXY` environment variables.
+
+## Requirements
+- Ruby (preferably a recent version)
+
+## Installation
+No specific installation steps are required other than having Ruby installed on your system. Simply download or clone the script to your local machine.
+
+## Usage
+The script can be run in two modes:
+1. **Basic Mode:** Make an HTTP or HTTPS GET request without a custom CA certificate.
+2. **CA Certificate Mode:** Make an HTTP or HTTPS GET request with a custom CA certificate.
+
+### Basic Mode
+```
+ruby app.rb [URL]
+```
+Replace `[URL]` with the desired HTTP or HTTPS URL.
+
+### CA Certificate Mode
+```
+ruby app.rb [URL] [CA-Certificate-File]
+```
+- Replace `[URL]` with the desired HTTP or HTTPS URL.
+- Replace `[CA-Certificate-File]` with the path to your CA certificate file.
+
+## Proxy Support
+If `HTTP_PROXY` or `HTTPS_PROXY` environment variables are set, the script will use these proxies for making the requests. Set these environment variables in your shell to use a proxy.
+
+## Examples
+1. Basic Mode:
+   ```
+   ruby app.rb https://example.com
+   ```
+2. CA Certificate Mode:
+   ```
+   ruby app.rb https://example.com /path/to/ca-cert.pem
+   ```
+
+## Note
+- The CA certificate file should be in PEM format.
+- The script handles both HTTP and HTTPS protocols and respects proxy settings defined in environment variables.

--- a/apps/impl-ruby/app.rb
+++ b/apps/impl-ruby/app.rb
@@ -1,0 +1,42 @@
+require 'net/http'
+require 'openssl'
+require 'uri'
+
+def make_request(url, ca_cert_file = nil)
+  uri = URI(url)
+  http = Net::HTTP.new(uri.host, uri.port)
+
+  if uri.scheme == 'https'
+    http.use_ssl = true
+    http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+
+    if ca_cert_file
+      store = OpenSSL::X509::Store.new
+      store.add_file(ca_cert_file)
+      http.cert_store = store
+    end
+  end
+
+  request = Net::HTTP::Get.new(uri)
+  response = http.request(request)
+
+  puts "STATUS: #{response.code}"
+  puts "HEADERS:"
+  response.each_header do |key, value|
+    puts "  #{key}: #{value}"
+  end
+  # Printing the body is not necessary for this example
+  # puts "BODY:"
+  # puts response.body
+rescue => e
+  puts "Error making request: #{e.message}"
+end
+
+if ARGV.length < 1
+  puts "Usage: ruby app.rb [URL] [optional: ca-certificate-file]"
+  exit 1
+end
+
+url = ARGV[0]
+ca_cert_file = ARGV[1]
+make_request(url, ca_cert_file)

--- a/apps/impl-ruby/deployment.yaml
+++ b/apps/impl-ruby/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: impl-ruby
+  namespace: impl-ruby
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: impl-ruby
+  template:
+    metadata:
+      labels:
+        app: impl-ruby
+    spec:
+      containers:
+      - name: impl-ruby
+        image: demo-impl-ruby
+        imagePullPolicy: Never

--- a/apps/impl-ruby/init.sh
+++ b/apps/impl-ruby/init.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+bin/kubectl delete -f "$1"/deployment.yaml --ignore-not-found
+bin/kubectl apply -f "$1"/deployment.yaml


### PR DESCRIPTION
This adds a simple implementation example for Ruby on how http clients can be configured to respect http(s)_proxy as well as optionally inject a trusted CA cert directly into Ruby http client versus trusting it at a system level.
