### PR TITLE
Add basic NGINX ingress demo setup

### DIFF
--- a/apps/nginx/Dockerfile
+++ b/apps/nginx/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:latest
+COPY ./index.html /usr/share/nginx/html/index.html

--- a/apps/nginx/README.md
+++ b/apps/nginx/README.md
@@ -1,0 +1,12 @@
+# NGINX Deployment and Headless Service
+
+## Overview
+
+Makes use of <https://hub.docker.com/_/nginx> to build a minimal NGINX image to serve up a static site.
+
+
+## Headless Service
+
+A headless service (<https://kubernetes.io/docs/concepts/services-networking/service/#headless-services>) is used to get a DNS record for the NGINX pod.
+
+The pod will be available at `nginx.nginx.svc.cluster.local`.

--- a/apps/nginx/deployment.yaml
+++ b/apps/nginx/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: demo-nginx
+        imagePullPolicy: Never

--- a/apps/nginx/index.html
+++ b/apps/nginx/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title>Docker Nginx</title>
+</head>
+
+<body>
+    <h2>Hello from Nginx container</h2>
+</body>
+
+</html>

--- a/apps/nginx/init.sh
+++ b/apps/nginx/init.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+bin/kubectl delete -f "$1"/deployment.yaml --ignore-not-found
+bin/kubectl apply -f "$1"/deployment.yaml
+
+bin/kubectl delete -f "$1"/service.yaml --ignore-not-found
+bin/kubectl apply -f "$1"/service.yaml

--- a/apps/nginx/service.yaml
+++ b/apps/nginx/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: nginx
+spec:
+  ports:
+    - port: 80
+      name: http
+  clusterIP: None
+  selector:
+    app: nginx

--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,7 @@ install_kubectl() {
   if [ -f "bin/kubectl" ]; then
     return 0
   fi
-  
+
   # ensure bin dir
   mkdir -p bin
 
@@ -66,11 +66,11 @@ install_kind() {
   if [ -f "bin/kind" ]; then
     return 0
   fi
-  
+
   # ensure bin dir
   mkdir -p bin
 
-  # install 
+  # install
   curl -Lo bin/kind "https://kind.sigs.k8s.io/dl/v0.20.0/kind-${platform}-${architecture}"
 
   # ensure executable
@@ -84,7 +84,7 @@ install_helm() {
   if [ -f "bin/helm" ]; then
     return 0
   fi
-  
+
   # ensure bin dir
   mkdir -p bin
 


### PR DESCRIPTION
This loosely follows https://www.docker.com/blog/how-to-use-the-official-nginx-docker-image/ to produce a Docker image which serves up a static HTML page. A headless service is used to give the pod a DNS record for use for ingress routing.