### PR TITLE
Move us to node v1.29.4 for the cluster

### DIFF
--- a/kubernetes/Dockerfile
+++ b/kubernetes/Dockerfile
@@ -1,4 +1,0 @@
-# Use the latest
-FROM kindest/node:v1.27.3
-
-# todo: customize base node?

--- a/kubernetes/Makefile
+++ b/kubernetes/Makefile
@@ -42,15 +42,12 @@ ensure-images: docker ## Ensure all app images exist, build them if not
 		fi; \
 	done
 
-build-node: docker ## Build the docker node image used to bootstrap KinD cluster
-	docker build -t demo-kind-node:latest .
-
 build: build-images ## Build the necessary resources for the environment
 
 ##@ Environment
 
 cluster: kind ## Create the KinD cluster to run demo scenarios
-	@$(KIND) get clusters | grep -qw "^demo$$" || $(KIND) create cluster --config kind-config.yaml --name demo
+	@$(KIND) get clusters | grep -qw "^demo$$" || $(KIND) create cluster --config kind-config.yaml --image kindest/node:v1.29.4 --name demo
 
 cert-manager: ## Install cert-manager on the KinD cluster
 	@echo "Installing cert-manager..." && \


### PR DESCRIPTION
This moves us to a more recent Kubernetes version. It isn't the latest stable which is:
```
curl -L -s https://dl.k8s.io/release/stable.txt
v1.30.2
```
but it is a version within the Kubernetes supported versions. Kind is always behind a little on node versions and tracking stable.

This is what it looks like when bringing up a cluster:
```
make cluster
No kind clusters found.
Creating cluster "demo" ...
 ✓ Ensuring node image (kindest/node:v1.29.4) 🖼
 ✓ Preparing nodes 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing CNI 🔌
 ✓ Installing StorageClass 💾
Set kubectl context to "kind-demo"
You can now use your cluster with:

kubectl cluster-info --context kind-demo

Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
```